### PR TITLE
Remove unused array_get method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+### In Developemnt - (Dev time: 0.5 hour) ###
+- Docs: Removed unused array_get() method
+
 ### v1.8.2 (2016-04-20) - (Dev time: 1 hour) ###
 - Tweak: Log all emails from the TO field. Earlier the plugin was logging only the first email
 - Fix: Fixed issues in parsing reply-to and content-type headers

--- a/email-log.php
+++ b/email-log.php
@@ -338,20 +338,6 @@ class EmailLog {
 
 		return $mail_info;
 	}
-
-	/**
-	 * Check whether a key is present.
-	 *
-	 * If present returns the value, else returns the default value
-	 *
-	 * @param  array  $array   Array whose key has to be checked
-	 * @param  string $key     Key that has to be checked
-	 * @param  string $default The default value that has to be used, if the key is not found (optional)
-	 * @return mixed           If present returns the value, else returns the default value
-	 */
-	private function array_get( $array, $key, $default = null ) {
-		return isset( $array[ $key ] ) ? $array[ $key ] : $default;
-	}
 }
 
 /**


### PR DESCRIPTION
Fix #32

**Description**
The unused array_get() method has been removed and respective history included.