### PR TITLE
Implement `el_wp_mail_log` filter in EmailLogger class

### DIFF
--- a/include/Core/EmailLogger.php
+++ b/include/Core/EmailLogger.php
@@ -24,6 +24,19 @@ class EmailLogger {
 	 */
 	public function log_email( $mail_info ) {
 		$email_log = email_log();
+		/**
+		 * Hook to modify wp_mail contents before Email Log plugin logs.
+		 *
+		 * @since Genesis
+		 *
+		 * @param array $mail_info {
+		 *     @type string $to
+		 *     @type string $subject
+		 *     @type string $message
+		 *     @type string $headers
+		 *     @type string $attachment
+		 * }
+		 */
 		$mail_info = apply_filters( 'el_wp_mail_log', $mail_info );
 
 		$headers = '';

--- a/include/Core/EmailLogger.php
+++ b/include/Core/EmailLogger.php
@@ -24,6 +24,7 @@ class EmailLogger {
 	 */
 	public function log_email( $mail_info ) {
 		$email_log = email_log();
+		$mail_info = apply_filters( 'el_wp_mail_log', $mail_info );
 
 		$headers = '';
 		if ( isset( $mail_info['headers'] ) ) {


### PR DESCRIPTION
`el_wp_mail_log` filter is used by Forward Email addon to hook email addresses to `wp_mail` function