### PR TITLE
227 fix/scrutinizer issues

### DIFF
--- a/include/Util/helper.php
+++ b/include/Util/helper.php
@@ -143,11 +143,7 @@ function join_array_elements_with_delimiter( $value, $delimiter = ',' ) {
  * @return string
  */
 function get_user_defined_date_time_format() {
-	return sprintf(
-		'%1$s %2$s',
-		/** @scrutinizer ignore-type */ get_option( 'date_format', 'Y-m-d' ),
-		/** @scrutinizer ignore-type */ get_option( 'time_format', 'g:i a' )
-	);
+	return sprintf( '%1$s %2$s', get_option( 'date_format', 'Y-m-d' ), get_option( 'time_format', 'g:i a' ) );
 }
 
 /**

--- a/include/Util/helper.php
+++ b/include/Util/helper.php
@@ -143,7 +143,11 @@ function join_array_elements_with_delimiter( $value, $delimiter = ',' ) {
  * @return string
  */
 function get_user_defined_date_time_format() {
-	return sprintf( '%1$s %2$s', get_option( 'date_format', 'Y-m-d' ), get_option( 'time_format', 'g:i a' ) );
+	return sprintf(
+		'%1$s %2$s',
+		/** @scrutinizer ignore-type */ get_option( 'date_format', 'Y-m-d' ),
+		/** @scrutinizer ignore-type */ get_option( 'time_format', 'g:i a' )
+	);
 }
 
 /**

--- a/include/Util/helper.php
+++ b/include/Util/helper.php
@@ -339,8 +339,8 @@ function get_email_log_columns() {
  */
 function get_masked_value( $value, $mask_char, $percent ) {
 	$len        = strlen( $value );
-	$mask_count = floor( $len * $percent / 100 );
-	$offset     = floor( ( $len - $mask_count ) / 2 );
+	$mask_count = (int) floor( $len * $percent / 100 );
+	$offset     = (int) floor( ( $len - $mask_count ) / 2 );
 
 	return substr( $value, 0, $offset )
 	       . str_repeat( $mask_char, $mask_count )


### PR DESCRIPTION
Fixes https://github.com/sudar/email-log/issues/227

Scrutinizer annotation is used in the following places since it is obvious that `get_option()` will return the default value when no option value is found.

- https://github.com/sudar/email-log/compare/227-fix/scrutinizer-issues?expand=1#diff-55d21dc299c734208c354fbbf4ed67a8R148
- https://github.com/sudar/email-log/compare/227-fix/scrutinizer-issues?expand=1#diff-55d21dc299c734208c354fbbf4ed67a8R149

**Using Scrutinizer annotation creates a Style CI issue**.

![image](https://user-images.githubusercontent.com/17510033/60939085-06b8b900-a2f4-11e9-83b3-a12704c1de13.png)

I don't agree w/ Style CI fix, but if that's how it is supposed to work, then I've created another PR for the same.

https://github.com/sudar/email-log/pull/229/files

Kindly verify if the above PR is required and merge that first before merging this PR.