### PR TITLE
Show active tab by Email's content type

### DIFF
--- a/assets/css/admin/view-logs.css
+++ b/assets/css/admin/view-logs.css
@@ -8,7 +8,7 @@
 	margin-top: 10px;
 }
 
-.tabs-text-textarea {
+.tabs-text-pre {
 	height: 100%;
 	width: 100%;
 }

--- a/assets/js/admin/view-logs.js
+++ b/assets/js/admin/view-logs.js
@@ -20,9 +20,10 @@
 	});
 
 	$( document ).on( tabsInsertedEvent, function() {
-		var activeTabIndex = parseInt( $( '#tabs ul' ).data( 'active' ) );
+		var activeTabIndex = parseInt( $( "#tabs ul" ).data( "active-tab" ) );
+
 		activeTabIndex = isNaN( activeTabIndex ) ? 1 : activeTabIndex;
-		$( '#tabs' ).tabs( { active: activeTabIndex } );
+		$( "#tabs" ).tabs( { active: activeTabIndex } );
 	} );
 
 })( jQuery );

--- a/assets/js/admin/view-logs.js
+++ b/assets/js/admin/view-logs.js
@@ -19,8 +19,10 @@
 		$( element ).trigger( tabsInsertedEvent )
 	});
 
-	$( document ).on( tabsInsertedEvent, function () {
-		$( '#tabs' ).tabs( { active: 1 } );
-	});
+	$( document ).on( tabsInsertedEvent, function() {
+		var activeTabIndex = parseInt( $( '#tabs ul' ).data( 'active' ) );
+		activeTabIndex = isNaN( activeTabIndex ) ? 1 : activeTabIndex;
+		$( '#tabs' ).tabs( { active: activeTabIndex } );
+	} );
 
 })( jQuery );

--- a/include/Core/Request/LogListAction.php
+++ b/include/Core/Request/LogListAction.php
@@ -26,6 +26,7 @@ class LogListAction implements Loadie {
 	/**
 	 * AJAX callback for displaying email content.
 	 *
+	 * @since 2.4.0 Show Active Tab based on the Email's content type.
 	 * @since 1.6
 	 */
 	public function view_log_message() {
@@ -42,6 +43,19 @@ class LogListAction implements Loadie {
 		$log_items = $this->get_table_manager()->fetch_log_items_by_id( array( $id ) );
 		if ( count( $log_items ) > 0 ) {
 			$log_item = $log_items[0];
+
+			$content_type_active_attr = ' data-active=0';
+			$headers                  = array();
+			if ( ! empty( $log_item['headers'] ) ) {
+				$parser  = new \EmailLog\Util\EmailHeaderParser();
+				$headers = $parser->parse_headers( $log_item['headers'] );
+			}
+
+			// Avoid NPath complexity
+			if ( isset( $headers['content_type'] ) &&
+			     'text/html' === $headers['content_type'] ) {
+				$content_type_active_attr = ' data-active=1';
+			}
 
 			ob_start();
 			?>
@@ -74,7 +88,7 @@ class LogListAction implements Loadie {
 			</table>
 
 			<div id="tabs">
-				<ul>
+				<ul <?php echo esc_html( $content_type_active_attr ); ?>>
 					<li><a href="#tabs-text"><?php _e( 'Raw Email Content', 'email-log' ); ?></a></li>
 					<li><a href="#tabs-preview"><?php _e( 'Preview Content as HTML', 'email-log' ); ?></a></li>
 				</ul>

--- a/include/Core/Request/LogListAction.php
+++ b/include/Core/Request/LogListAction.php
@@ -46,17 +46,15 @@ class LogListAction implements Loadie {
 		if ( count( $log_items ) > 0 ) {
 			$log_item = $log_items[0];
 
-			$content_type_active_attr = ' data-active=0';
-			$headers                  = array();
+			$headers = array();
 			if ( ! empty( $log_item['headers'] ) ) {
 				$parser  = new \EmailLog\Util\EmailHeaderParser();
 				$headers = $parser->parse_headers( $log_item['headers'] );
 			}
 
-			// Avoid NPath complexity
-			if ( isset( $headers['content_type'] ) &&
-			     'text/html' === $headers['content_type'] ) {
-				$content_type_active_attr = ' data-active=1';
+			$active_tab = '0';
+			if ( isset( $headers['content_type'] ) && 'text/html' === $headers['content_type'] ) {
+				$active_tab = '1';
 			}
 
 			ob_start();
@@ -90,14 +88,13 @@ class LogListAction implements Loadie {
 			</table>
 
 			<div id="tabs">
-				<ul <?php echo esc_html( $content_type_active_attr ); ?>>
+				<ul data-active-tab="<?php echo absint( $active_tab ); ?>">
 					<li><a href="#tabs-text"><?php _e( 'Raw Email Content', 'email-log' ); ?></a></li>
 					<li><a href="#tabs-preview"><?php _e( 'Preview Content as HTML', 'email-log' ); ?></a></li>
 				</ul>
 
 				<div id="tabs-text">
-					<pre class="tabs-text-pre"><?php echo esc_textarea( $log_item['message'] );
-					?></pre>
+					<pre class="tabs-text-pre"><?php echo esc_textarea( $log_item['message'] ); ?></pre>
 				</div>
 
 				<div id="tabs-preview">
@@ -110,8 +107,7 @@ class LogListAction implements Loadie {
 			</div>
 
 			<?php
-			$output = ob_get_clean();
-			echo $output;
+			echo ob_get_clean();
 		}
 
 		wp_die(); // this is required to return a proper result.

--- a/include/Core/Request/LogListAction.php
+++ b/include/Core/Request/LogListAction.php
@@ -13,6 +13,8 @@ class LogListAction implements Loadie {
 	/**
 	 * Setup actions.
 	 *
+	 * @since 2.4.0 Display Plain type email using <pre>.
+	 *
 	 * @inheritdoc
 	 */
 	public function load() {
@@ -94,7 +96,8 @@ class LogListAction implements Loadie {
 				</ul>
 
 				<div id="tabs-text">
-					<textarea class="tabs-text-textarea"><?php echo esc_textarea( $log_item['message'] ); ?></textarea>
+					<pre class="tabs-text-pre"><?php echo esc_textarea( $log_item['message'] );
+					?></pre>
 				</div>
 
 				<div id="tabs-preview">


### PR DESCRIPTION
Fix https://github.com/sudar/email-log/issues/232
Fix https://github.com/sudar/email-log/issues/233

### Summary

- The Active tab is determined by parsing the  Content type specified in the Header column. When the Content type is not specified, the email is considered to be a plain text email.