### PR TITLE
fix: function _load_textdomain_just_in_time issue

### DIFF
--- a/include/Core/EmailLog.php
+++ b/include/Core/EmailLog.php
@@ -28,6 +28,7 @@ class EmailLog {
 	 * Flag to track if the plugin is loaded.
 	 *
 	 * @since 2.0
+	 *
 	 * @access private
 	 *
 	 * @var bool
@@ -38,6 +39,7 @@ class EmailLog {
 	 * Flag to override plugin API.
 	 *
 	 * @since 2.4.5
+	 *
 	 * @access private
 	 *
 	 * @var bool
@@ -48,6 +50,7 @@ class EmailLog {
 	 * Plugin file path.
 	 *
 	 * @since 2.0
+	 *
 	 * @access private
 	 *
 	 * @var string
@@ -156,7 +159,7 @@ class EmailLog {
 	}
 
 	/**
-	 * Load Textdomain
+	 * Load Textdomain.
 	 */
 	public function load_textdomain() {
 		if ( $this->loaded ) {

--- a/include/Core/EmailLog.php
+++ b/include/Core/EmailLog.php
@@ -156,14 +156,23 @@ class EmailLog {
 	}
 
 	/**
+	 * Load Textdomain
+	 */
+	public function load_textdomain() {
+		if ( $this->loaded ) {
+			return;
+		}
+
+		load_plugin_textdomain( 'email-log', false, $this->translations_path );
+	}
+
+	/**
 	 * Load the plugin.
 	 */
 	public function load() {
 		if ( $this->loaded ) {
 			return;
 		}
-
-		load_plugin_textdomain( 'email-log', false, $this->translations_path );
 
 		$this->table_manager->load();
 

--- a/load-email-log.php
+++ b/load-email-log.php
@@ -65,6 +65,7 @@ function load_email_log( $plugin_file ) {
 	// Ideally the plugin should be loaded in a later event like `init` or `wp_loaded`.
 	// But some plugins like EDD are sending emails in `init` event itself,
 	// which won't be logged if the plugin is loaded in `wp_loaded` or `init`.
+	add_action( 'init', array( $email_log, 'load_textdomain' ), 101 );
 	add_action( 'plugins_loaded', array( $email_log, 'load' ), 101 );
 }
 


### PR DESCRIPTION
## Fix: Load Translations at the Correct Hook for email-log
## Summary

This PR resolves an issue where the `_load_textdomain_just_in_time` function was being called too early, triggering a WordPress notice in version 6.7.0. The fix ensures that translations for the `email-log` text domain are loaded at the correct hook (`init` or later) to comply with WordPress best practices.

## Closed Issue #355 

## Changes

- Adjusted the translation loading logic to execute at the init action hook.

- Prevented premature execution that caused the debug notice in functions.php line 6114.

## Testing
- Enabled WP_DEBUG to verify that the notice no longer appears.
- Tested email log functionality to confirm that translations still load correctly.

## References

- [WordPress Debugging Guide](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress)

## Reviewers
- Please review and let me know if any further adjustments are needed. 🚀